### PR TITLE
Set email address and token with environment variables

### DIFF
--- a/submit.py
+++ b/submit.py
@@ -45,8 +45,8 @@ Part = namedtuple("Part", ['id', 'input_file', 'solver_file', 'name'])
 
 email_prompt = 'User Name (e-mail address): '
 token_prompt = 'Submission Token (from the assignment page): '
-email_env_var = 'EMAIL_ADDRESS'
-token_env_var = 'DOTOKEN'
+email_env_var = 'DO_EMAIL_ADDRESS'
+token_env_var = 'DO_TOKEN'
 
 
 def load_metadata(metadata_file_name='_coursera'):

--- a/submit.py
+++ b/submit.py
@@ -43,6 +43,11 @@ submitt_url = \
 Metadata = namedtuple("Metadata", ['assignment_key', 'name', 'part_data'])
 Part = namedtuple("Part", ['id', 'input_file', 'solver_file', 'name'])
 
+email_prompt = 'User Name (e-mail address): '
+token_prompt = 'Submission Token (from the assignment page): '
+email_env_var = 'EMAIL_ADDRESS'
+token_env_var = 'DOTOKEN'
+
 
 def load_metadata(metadata_file_name='_coursera'):
     '''
@@ -297,8 +302,8 @@ def basic_prompt():
     Returns:
         the user's login and token
     '''
-    login = input('User Name (e-mail address): ')
-    token = input('Submission Token (from the assignment page): ')
+    login = os.environ.get(email_env_var) or input(email_prompt)
+    token = os.environ.get(token_env_var) or input(token_prompt)
     return login, token
 
 


### PR DESCRIPTION
With this patch students will not have to provide their email addresses each time they run submit.py. Instead submit.py will read values found in environment variables. If the environment variables are not set or if they are set to values which evaluate to false then, submit.py will prompt the student to provide those variables in the same manner it did prior to this patch.

Because the tokens only last thirty minutes it is unlikely that students will benefit from setting the environment variable for the token with .bashrc or equivalent. However, I would have enjoyed the option to set that env var manually for the times I executed submit.py while doing the first exercise.