### PR TITLE
add knapsack solver script for binary executable;

### DIFF
--- a/knapsack/solverShell.py
+++ b/knapsack/solverShell.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import os
+from subprocess import Popen, PIPE
+
+def solve_it(input_data):
+
+    # Writes the inputData to a temporay file
+
+    tmp_file_name = 'tmp.data'
+    tmp_file = open(tmp_file_name, 'w')
+    tmp_file.write(input_data)
+    tmp_file.close()
+
+    # NB! dont forget to compile binary, e.g rustc knapsack.rs
+    # Runs the command: cat tmp_file_name | ./knapsack
+    # and pipes the content of a tmp_file directly into executable
+    process = Popen(['cat ' + tmp_file_name + ' | ./knapsack'],
+        stdout=PIPE, shell = True, universal_newlines = True
+    )
+    (stdout, stderr) = process.communicate()
+
+    # removes the temporay file
+    os.remove(tmp_file_name)
+
+    return stdout.strip()
+
+
+import sys
+
+if __name__ == '__main__':
+    if len(sys.argv) > 1:
+        file_location = sys.argv[1].strip()
+        with open(file_location, 'r') as input_data_file:
+            input_data = input_data_file.read()
+        print(solve_it(input_data))
+    else:
+        print('This test requires an input file.  Please select one from the data directory. (i.e. python solver.py ./data/ks_4_0)')
+


### PR DESCRIPTION
Hi,

this PR adds an additional solver.py script to call compiled executable and it passes a content of a test file via stdin. This way a solution doesn't have to deal with file opening & closing;

Testing:
1. copy knapsack.rs from here: https://gist.github.com/timgluz/0a41ee27e37ccbd68c79400197ba4bf6

2. compile the example solution: `rustc knapsack.rs` 
nb: here's a tutorial how to install Rust: https://www.rust-lang.org/tools/install

3. test the script: `python solverBash.py ./data/ks_4_0`